### PR TITLE
Untitled Pull Request

### DIFF
--- a/Sources/URLRouting/Client/Client.swift
+++ b/Sources/URLRouting/Client/Client.swift
@@ -41,6 +41,20 @@ public struct URLRoutingClient<Route> {
       throw URLRoutingDecodingError(bytes: data, response: response, underlyingError: error)
     }
   }
+
+  /// Allows you to create a client that only handles a subset of routes.
+  ///
+  /// - Parameters:
+  ///    - toRoute: A closure that converts `ChildRoute` back to `Route`.
+  ///
+  /// - Returns: A client that can only request child routes.
+  public func scoped<ChildRoute>(
+    to toRoute: @escaping (ChildRoute) -> Route
+  ) -> URLRoutingClient<ChildRoute> {
+    .init { child in
+      try await self.request(toRoute(child))
+    }
+  }
 }
 
 public struct URLRoutingDecodingError: Error {

--- a/Tests/URLRoutingTests/ClientTests.swift
+++ b/Tests/URLRoutingTests/ClientTests.swift
@@ -43,4 +43,16 @@ class ClientTests: XCTestCase {
     XCTAssertEqual("result", value)
     XCTAssertEqual(200, (response as! HTTPURLResponse).statusCode)
   }
+
+  func testScoped() async throws {
+    let client = URLRoutingClient<TestRoute>.failing
+      .override(.child(.one)) { try .ok("result") }
+
+    let scopedClient = client.scoped(to: TestRoute.child)
+
+    let (value, response) = try await scopedClient.request(.one, as: String.self)
+
+    XCTAssertEqual("result", value)
+    XCTAssertEqual(200, (response as! HTTPURLResponse).statusCode)
+  }
 }

--- a/Tests/URLRoutingTests/ClientTests.swift
+++ b/Tests/URLRoutingTests/ClientTests.swift
@@ -1,0 +1,46 @@
+import Parsing
+import URLRouting
+import XCTest
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+class ClientTests: XCTestCase {
+  enum TestRoute: Equatable {
+    case one
+    case child(ChildRoute)
+  }
+
+  enum ChildRoute: Equatable {
+    case one
+    case two
+  }
+
+  static let router = OneOf {
+    Route(.case(TestRoute.one)) {
+      Path { "one" }
+    }
+    Route(.case(TestRoute.child)) {
+      Path { "child" }
+      OneOf {
+        Route(.case(ChildRoute.one)) {
+          Path { "one" }
+        }
+        Route(.case(ChildRoute.two)) {
+          Path { "two" }
+        }
+      }
+    }
+  }
+
+  func testBasics() async throws {
+    let client = URLRoutingClient<TestRoute>.failing
+      .override(.one) { try .ok("result") }
+
+    let (value, response) = try await client.request(.one, as: String.self)
+
+    XCTAssertEqual("result", value)
+    XCTAssertEqual(200, (response as! HTTPURLResponse).statusCode)
+  }
+}


### PR DESCRIPTION
Adds a new `.scoped` operator on `URLRoutingClient` that can be used to create scoped clients.

This supports a use case where your main client may support a large number of routes and you only want to be able to pass around a client that handles a sub-set of those routes as a dependency. For instance, imagine a feature domain within a TCA app - your `AppEnvironment` may hold onto a `URLRoutingClient<AppRoute>` client but your account feature may only need to make requests to account-related routes, so you'd like to pass a `URLRoutingClient<AccountRoute>` client to that domain's environment, limiting its scope and making it easier for you to find the right route at the call-site.

I debated over whether or not to call this `scoped` or `pullback` - I _think_ the shape of this function is a `pullback` but the term "scope" or "scoped" felt more ergonomic to me in this context.